### PR TITLE
Made delegate reference strong

### DIFF
--- a/ZXingObjC/multi/ZXGenericMultipleBarcodeReader.m
+++ b/ZXingObjC/multi/ZXGenericMultipleBarcodeReader.m
@@ -24,7 +24,7 @@ const int ZX_MAX_DEPTH = 4;
 
 @interface ZXGenericMultipleBarcodeReader ()
 
-@property (nonatomic, weak, readonly) id<ZXReader> delegate;
+@property (nonatomic, readonly) id<ZXReader> delegate;
 
 @end
 


### PR DESCRIPTION
This should fix bug #299 that multiple barcodes fail when using swift. At least worked for me